### PR TITLE
receated the teams table

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,3 +1,3 @@
 class Team < ApplicationRecord
-  validates :name, presense: true
+
 end

--- a/db/migrate/20190209193038_drop_team.rb
+++ b/db/migrate/20190209193038_drop_team.rb
@@ -1,0 +1,8 @@
+class DropTeam < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :teams do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190209193516_recreate_team.rb
+++ b/db/migrate/20190209193516_recreate_team.rb
@@ -1,0 +1,72 @@
+class RecreateTeam < ActiveRecord::Migration[5.2]
+  def change
+    create_table :teams do |t|
+      t.string :team_1
+      t.string :team_2
+      t.string :team_3
+      t.string :team_4
+      t.string :team_5
+      t.string :team_6
+      t.string :team_7
+      t.string :team_8
+      t.string :team_9
+      t.string :team_10
+      t.string :team_11
+      t.string :team_12
+      t.string :team_13
+      t.string :team_14
+      t.string :team_15
+      t.string :team_16
+      t.string :team_17
+      t.string :team_18
+      t.string :team_19
+      t.string :team_20
+      t.string :team_21
+      t.string :team_22
+      t.string :team_23
+      t.string :team_24
+      t.string :team_25
+      t.string :team_26
+      t.string :team_27
+      t.string :team_28
+      t.string :team_29
+      t.string :team_30
+      t.string :team_31
+      t.string :team_32
+      t.string :team_33
+      t.string :team_34
+      t.string :team_35
+      t.string :team_36
+      t.string :team_37
+      t.string :team_38
+      t.string :team_39
+      t.string :team_40
+      t.string :team_41
+      t.string :team_42
+      t.string :team_43
+      t.string :team_44
+      t.string :team_45
+      t.string :team_46
+      t.string :team_47
+      t.string :team_48
+      t.string :team_49
+      t.string :team_50
+      t.string :team_51
+      t.string :team_52
+      t.string :team_53
+      t.string :team_54
+      t.string :team_55
+      t.string :team_56
+      t.string :team_57
+      t.string :team_58
+      t.string :team_59
+      t.string :team_60
+      t.string :team_61
+      t.string :team_62
+      t.string :team_63
+      t.string :team_64
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_08_160720) do
+ActiveRecord::Schema.define(version: 2019_02_09_193516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,7 +86,70 @@ ActiveRecord::Schema.define(version: 2019_02_08_160720) do
   end
 
   create_table "teams", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "team_1"
+    t.string "team_2"
+    t.string "team_3"
+    t.string "team_4"
+    t.string "team_5"
+    t.string "team_6"
+    t.string "team_7"
+    t.string "team_8"
+    t.string "team_9"
+    t.string "team_10"
+    t.string "team_11"
+    t.string "team_12"
+    t.string "team_13"
+    t.string "team_14"
+    t.string "team_15"
+    t.string "team_16"
+    t.string "team_17"
+    t.string "team_18"
+    t.string "team_19"
+    t.string "team_20"
+    t.string "team_21"
+    t.string "team_22"
+    t.string "team_23"
+    t.string "team_24"
+    t.string "team_25"
+    t.string "team_26"
+    t.string "team_27"
+    t.string "team_28"
+    t.string "team_29"
+    t.string "team_30"
+    t.string "team_31"
+    t.string "team_32"
+    t.string "team_33"
+    t.string "team_34"
+    t.string "team_35"
+    t.string "team_36"
+    t.string "team_37"
+    t.string "team_38"
+    t.string "team_39"
+    t.string "team_40"
+    t.string "team_41"
+    t.string "team_42"
+    t.string "team_43"
+    t.string "team_44"
+    t.string "team_45"
+    t.string "team_46"
+    t.string "team_47"
+    t.string "team_48"
+    t.string "team_49"
+    t.string "team_50"
+    t.string "team_51"
+    t.string "team_52"
+    t.string "team_53"
+    t.string "team_54"
+    t.string "team_55"
+    t.string "team_56"
+    t.string "team_57"
+    t.string "team_58"
+    t.string "team_59"
+    t.string "team_60"
+    t.string "team_61"
+    t.string "team_62"
+    t.string "team_63"
+    t.string "team_64"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
After spending much time thinking about, I dropped the existing teams table and recreated it.  I created a column for each team, 1 to 64.  I didn't want to rely on the team_id because that might not actually be 1 to 64.  I wanted to code the project abstractly with team_1, team_2 and so forth.

I hope that this is correct.  Also, I think that this may be a non-relational table compared to the users and brackets table.  The teams table might as well be an array of teams names 0..63 or a hash of team-number and team-name key-value pairing, team_1: "Butler".  We'll see what happens.